### PR TITLE
fixed sbt binary permission

### DIFF
--- a/slave/sbt/Dockerfile
+++ b/slave/sbt/Dockerfile
@@ -6,6 +6,6 @@ ENV SBT_VERSION=0.13.9 \
 RUN mkdir -p $SBT_HOME \
   && curl -L https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar > $SBT_HOME/sbt-launch.jar \
   && echo '#!/bin/bash\njava $SBT_OPTS -jar $SBT_HOME/sbt-launch.jar "$@"' > /usr/bin/sbt \
-  && chmod u+x /usr/bin/sbt \
+  && chmod a+x /usr/bin/sbt \
   && sbt exit \
   && rm -fr /tmp/*


### PR DESCRIPTION
jenkins-slave user don't have permission to sbt binary:

```
++ sbt -Dsbt.ivy.home=/opt/jenkins-slave/workspace/COMPONENTS/CC-TOOLS/CC-TOOLS-BUILD/.ivy2 sotac-shell/packageName
++ sed -n 3p
/tmp/hudson4940867789231394650.sh: line 6: /usr/bin/sbt: Permission denied
```

or it's better to change ownership for jenkins-slave groups like 998 or 999 and change permissions to g+x