### PR TITLE
fixed ownership of hidden directories to jankins-slave

### DIFF
--- a/slave/sbt/Dockerfile
+++ b/slave/sbt/Dockerfile
@@ -2,6 +2,7 @@ FROM oberthur/jenkins-slave-base:2.0.2
 
 ENV SBT_VERSION=0.13.9 \
     SBT_HOME=/usr/share/sbt
+    _JAVA_OPTIONS="-Dsbt.log.noformat=true ${_JAVA_OPTIONS}"
 
 RUN mkdir -p $SBT_HOME \
   && curl -L https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar > $SBT_HOME/sbt-launch.jar \

--- a/slave/sbt/Dockerfile
+++ b/slave/sbt/Dockerfile
@@ -1,8 +1,8 @@
 FROM oberthur/jenkins-slave-base:2.0.2
 
 ENV SBT_VERSION=0.13.9 \
-    SBT_HOME=/usr/share/sbt
-    _JAVA_OPTIONS="-Dsbt.log.noformat=true ${_JAVA_OPTIONS}" \
+    SBT_HOME=/usr/share/sbt \
+    _JAVA_OPTIONS="-Dsbt.log.noformat=true ${_JAVA_OPTIONS}"
 
 RUN mkdir -p $SBT_HOME \
   && curl -L https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar > $SBT_HOME/sbt-launch.jar \

--- a/slave/sbt/Dockerfile
+++ b/slave/sbt/Dockerfile
@@ -8,4 +8,5 @@ RUN mkdir -p $SBT_HOME \
   && echo '#!/bin/bash\njava $SBT_OPTS -jar $SBT_HOME/sbt-launch.jar "$@"' > /usr/bin/sbt \
   && chmod a+x /usr/bin/sbt \
   && sbt exit \
+  && chown -R jenkins-slave:jenkins-slave /opt/jenkins-slave/
   && rm -fr /tmp/*

--- a/slave/sbt/Dockerfile
+++ b/slave/sbt/Dockerfile
@@ -2,7 +2,7 @@ FROM oberthur/jenkins-slave-base:2.0.2
 
 ENV SBT_VERSION=0.13.9 \
     SBT_HOME=/usr/share/sbt
-    _JAVA_OPTIONS="-Dsbt.log.noformat=true ${_JAVA_OPTIONS}"
+    _JAVA_OPTIONS="-Dsbt.log.noformat=true ${_JAVA_OPTIONS}" \
 
 RUN mkdir -p $SBT_HOME \
   && curl -L https://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/$SBT_VERSION/sbt-launch.jar > $SBT_HOME/sbt-launch.jar \

--- a/slave/sbt/Dockerfile
+++ b/slave/sbt/Dockerfile
@@ -9,5 +9,5 @@ RUN mkdir -p $SBT_HOME \
   && echo '#!/bin/bash\njava $SBT_OPTS -jar $SBT_HOME/sbt-launch.jar "$@"' > /usr/bin/sbt \
   && chmod a+x /usr/bin/sbt \
   && sbt exit \
-  && chown -R jenkins-slave:jenkins-slave /opt/jenkins-slave/
+  && chown -R jenkins-slave:jenkins-slave /opt/jenkins-slave/ \
   && rm -fr /tmp/*


### PR DESCRIPTION
there is wrong ownership of hidden directories inside `/opt/jenkins-slave`

```
root@9d94404a8074:~# ls -la
total 1316
drwxr-xr-x 5 jenkins-slave jenkins-slave    4096 Jan 22 15:22 .
drwxr-xr-x 6 jenkins-slave jenkins-slave    4096 Jan 22 15:22 ..
drwxr-xr-x 3 root          root             4096 Jan 22 15:22 .ivy2
drwxr-xr-x 2 root          root             4096 Jan 22 15:22 .oracle_jre_usage
drwxr-xr-x 4 root          root             4096 Jan 22 15:23 .sbt
-rw-r--r-- 1 jenkins-slave jenkins-slave 1325307 Jan 21 13:19 swarm-client-2.0-jar-with-dependencies.ja
```