### PR TITLE
Updated README.md files to reflect real JENKINS_LABELS status

### DIFF
--- a/slave/android/README.md
+++ b/slave/android/README.md
@@ -10,7 +10,7 @@ Docker image to build Android applications
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default swarm)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/android/README.md
+++ b/slave/android/README.md
@@ -10,7 +10,7 @@ Docker image to build Android applications
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_SLAVE_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default empty)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/jdk7/README.md
+++ b/slave/jdk7/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default swarm)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/jdk7/README.md
+++ b/slave/jdk7/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_SLAVE_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default empty)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/jdk8/README.md
+++ b/slave/jdk8/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default swarm)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/jdk8/README.md
+++ b/slave/jdk8/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_SLAVE_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default empty)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/ruby/README.md
+++ b/slave/ruby/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default swarm)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/ruby/README.md
+++ b/slave/ruby/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_SLAVE_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default empty)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/simple/README.md
+++ b/slave/simple/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default swarm)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/simple/README.md
+++ b/slave/simple/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_SLAVE_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default empty)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/simplicate/README.md
+++ b/slave/simplicate/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default swarm)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)

--- a/slave/simplicate/README.md
+++ b/slave/simplicate/README.md
@@ -10,7 +10,7 @@ Docker image to run docker compose
 - JENKINS_PASSWORD - password (default empty)
 - JENKINS_SLAVE_NAME - slave name (default swarm)
 - JENKINS_URL - jenkins url (default 127.0.0.1)
-- JENKINS_SLAVE_LABELS - slave label (default empty)
+- JENKINS_LABELS - slave label (default empty)
 - JENKINS_FS_ROOT - fs root (default empty)
 - JENKINS_EXEC_NR - executor number (default 1)
 - JENKINS_MODE - normal or exclusive (default exclusive)


### PR DESCRIPTION
README.md files were showing wrong variable name and default value, this change reflects real names and defaults in scripts generated by Dockerfiles.