### PR TITLE
Upgrade android SDK + add build toold

### DIFF
--- a/slave/android/Dockerfile
+++ b/slave/android/Dockerfile
@@ -3,8 +3,8 @@ FROM oberthur/docker-ubuntu-java:jdk8_8.112.15
 ENV SWARM_VERSION=2.2 \
   GRADLE_VERSION=2.2 \
   MAVEN_VERSION=3.3.9 \
-  ANDROID_VERSION=22 \
-  ANDROID_SDK_VERSION=24.3.3 \
+  ANDROID_VERSION=25 \
+  ANDROID_SDK_VERSION=24.4.1 \
   GRADLE_HOME=/usr/share/gradle \
   MAVEN_HOME=/usr/share/maven \
   ANDROID_HOME=/opt/android-sdk-linux

--- a/slave/jdk8/Dockerfile
+++ b/slave/jdk8/Dockerfile
@@ -37,6 +37,9 @@ RUN curl -o /opt/swarm-client-${SWARM_VERSION}-jar-with-dependencies.jar http://
   # adding RSYNC MC
   && apt-get install -y mc rsync \
 
+  # adding BUILD-TOOLS
+  && apt-get install -y build-essential \
+
   # clean all cache to clean space
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean \


### PR DESCRIPTION
Adding to builder-jdk8 make tool which is included in 'build-tools' package is required by grunt to build angular UI without errors. 
Android SDK upgraded in builder-android to v25, build tools v25.0.1, I wasn`t able to downgrade our project to version already provided in builder.